### PR TITLE
Roll once

### DIFF
--- a/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
+++ b/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
@@ -14,9 +14,6 @@ SEE buffx.xml "RandomRoll" docs for a literal reference to this!
 
 -->
 
-<!-- Set vanilla global -->
-<set xpath="/buffs/buff[@name='buffStatusCheck01']/effect_group/triggered_effect[@trigger='onSelfEnteredGame'][@cvar='$infectionMaxDuration'][@operation='set']/@value">10800</set>
-
 <!-- Set vanilla default buff entry point -->
 <!-- 
 <set xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set']/@value">10800</set>
@@ -36,7 +33,7 @@ SEE buffx.xml "RandomRoll" docs for a literal reference to this!
  5% chance of having 30 minutes (1800 seconds)
 -->
 <!-- Add randomness to vanilla default buff entry point
-NOTE: RandomRoll might roll 1 time and the result be applied for all?
+NOTE: randomint rolls 1 time and the result is applied for all
 -->
   <!-- <append xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
   -->
@@ -44,41 +41,33 @@ NOTE: RandomRoll might roll 1 time and the result be applied for all?
 
     <effect_group> <!--Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
 
-		<triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800"> <!-- Duplicate what the game had with our max num  -->
-			<requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="0" /></triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="infectionSeverity" operation="set" value="randomint(0,100)"/>
 
-    <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="7200"> <!-- 2 hours  -->
-      <requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="10800"/>
-      <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="85"/>
-    </triggered_effect>
-
-    <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="5400"> <!-- 1.5 hours  -->
-      <requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="7200"/>
-      <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="65"/>
-    </triggered_effect>
-
-    <!-- Add randomness to vanilla default buff entry point -->
-    <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="3600"> <!-- 1 hour -->
-      <requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="5400"/>
-      <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="40"/>
-    </triggered_effect>
-
-    <!-- Add randomness to vanilla default buff entry point. Make this the "min" value (shortest to live) -->
-    <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="2700"> <!-- 45 minutes -->
-      <requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="3600"/>
-      <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="15"/>
-    </triggered_effect>
-
-    <!-- Add randomness to vanilla default buff entry point. Make this the "min" value (shortest to live) -->
-    <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="1800"> <!-- 30 minutes -->
-      <requirement name="CVarCompare" cvar="$infectionMaxDuration" operation="Equals" value="2700"/>
-      <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="5"/>
-    </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800">        <!-- 180 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="100"/>
+      </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="7200">        <!-- 120 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="85"/>
+      </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="5400">        <!-- 90 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="65"/>
+      </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="3600">        <!-- 60 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="40"/>
+      </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="2700">        <!-- 45 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="15"/>
+      </triggered_effect>
+      <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="1800">        <!-- 30 minutes -->
+        <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="5"/>
+      </triggered_effect>
 
     <!-- DEBUGGING -->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection timer set to:"/>-->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="$infectionMaxDuration"/>-->
-
+    <!-- f1, dm, buff buffinfection main, q-->
+    <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection severity set to:"/> -->
+    <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="infectionSeverity"/> -->
+    <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection timer set to:"/> -->
+    <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="$infectionMaxDuration"/> -->
 
     <!-- cleanup, as it seems to be set to the lowest it hit last time and does not reset -->
     <triggered_effect trigger="onSelfBuffRemove" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800"/>

--- a/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
+++ b/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
@@ -1,39 +1,46 @@
 <Doughs>
   <!--
-    Set to 10800 = 3 hour [real time not game time]
-    a19 default = 25200 = 7 hours [real time not game time]
+  Set to 10800 = 3 hour [real time not game time]
+  a19 default = 25200 = 7 hours [real time not game time]
 -->
 
-  <!--
-    Handle making random of how long it takes to die
-    15% chance of having 3 hours (10800 seconds) [real time]
-    20% chance of having 2 hours (7200 seconds)
-    25% chance of having 1.5 hours (5400 seconds)
-    25% chance of having 1 hour (3600 seconds)
-    10% chance of having 45 minutes (2700 seconds)
-    5% chance of having 30 minutes (1800 seconds)
+  <!-- WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
+SEE buffx.xml "RandomRoll" docs for a literal reference to this!
+<triggered_effect trigger="onSelfEnteredGame" action="ModifyCVar" cvar="$doughsGeneticInfectionMarker" operation="set" value="0"/>
+<requirement name="CVarCompare" cvar="$foodAmountAdd" operation="LTE" value="@$doughsGeneticInfectionMarker"/>
+
+# Maybe indulge in this?
+<triggered_effect trigger="onSelfBuffUpdate" action="ModifyCVar" cvar="test2" operation="set" value="randomint(1,10)"/>
+
 -->
 
-  <!--
-    WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
-    SEE buffx.xml "RandomRoll" docs for a literal reference to this!
-    <triggered_effect trigger="onSelfEnteredGame" action="ModifyCVar" cvar="$doughsGeneticInfectionMarker" operation="set" value="0"/>
-    <requirement name="CVarCompare" cvar="$foodAmountAdd" operation="LTE" value="@$doughsGeneticInfectionMarker"/>
-
-    # Maybe indulge in this?
-    <triggered_effect trigger="onSelfBuffUpdate" action="ModifyCVar" cvar="test2" operation="set" value="randomint(1,10)"/>
+  <!-- Set vanilla default buff entry point -->
+  <!-- 
+<set xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set']/@value">10800</set>
 -->
 
   <!-- Delete this as were moving it into our own effect group -->
   <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']/requirement"/>
   <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']"/>
 
-  <!-- Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
+  <!--
+ Handle "making random of how long it takes to die
+ 15% chance of having 3 hours (10800 seconds) [real time]
+ 20% chance of having 2 hours (7200 seconds)
+ 25% chance of having 1.5 hours (5400 seconds)
+ 25% chance of having 1 hour (3600 seconds)
+ 10% chance of having 45 minutes (2700 seconds)
+ 5% chance of having 30 minutes (1800 seconds)
+-->
+  <!-- Add randomness to vanilla default buff entry point
+NOTE: randomint rolls 1 time and the result is applied for all
+-->
+  <!-- <append xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
+  -->
   <insertBefore xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
 
-    <effect_group>
+    <effect_group>      <!--Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
 
-      <!-- Add randomness to vanilla default buff entry point (NOTE: randomint rolls 1 time and the result is applied for all) -->
       <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="infectionSeverity" operation="set" value="randomint(0,100)"/>
 
       <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800">        <!-- 180 minutes -->

--- a/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
+++ b/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
@@ -1,10 +1,10 @@
 <Doughs>
-<!--
+  <!--
   Set to 10800 = 2 hour [real time not game time]
   a19 default = 25200 = 7 hours [real time not game time]
 -->
 
-<!-- WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
+  <!-- WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
 SEE buffx.xml "RandomRoll" docs for a literal reference to this!
 <triggered_effect trigger="onSelfEnteredGame" action="ModifyCVar" cvar="$doughsGeneticInfectionMarker" operation="set" value="0"/>
 <requirement name="CVarCompare" cvar="$foodAmountAdd" operation="LTE" value="@$doughsGeneticInfectionMarker"/>
@@ -14,16 +14,16 @@ SEE buffx.xml "RandomRoll" docs for a literal reference to this!
 
 -->
 
-<!-- Set vanilla default buff entry point -->
-<!-- 
+  <!-- Set vanilla default buff entry point -->
+  <!-- 
 <set xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set']/@value">10800</set>
 -->
 
-<!-- Delete this as were moving it into our own effect group -->
-<remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']/requirement"/>
-<remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']"/>
+  <!-- Delete this as were moving it into our own effect group -->
+  <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']/requirement"/>
+  <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']"/>
 
-<!--
+  <!--
  Handle "making random of how long it takes to die
  15% chance of having 3 hours (10800 seconds) [real time]
  20% chance of having 2 hours (7200 seconds)
@@ -32,14 +32,14 @@ SEE buffx.xml "RandomRoll" docs for a literal reference to this!
  10% chance of having 45 minutes (2700 seconds)
  5% chance of having 30 minutes (1800 seconds)
 -->
-<!-- Add randomness to vanilla default buff entry point
+  <!-- Add randomness to vanilla default buff entry point
 NOTE: randomint rolls 1 time and the result is applied for all
 -->
   <!-- <append xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
   -->
   <insertBefore xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
 
-    <effect_group> <!--Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
+    <effect_group>      <!--Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
 
       <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="infectionSeverity" operation="set" value="randomint(0,100)"/>
 
@@ -62,17 +62,17 @@ NOTE: randomint rolls 1 time and the result is applied for all
         <requirement name="CVarCompare" cvar="infectionSeverity" operation="LTE" value="5"/>
       </triggered_effect>
 
-    <!-- DEBUGGING -->
-    <!-- f1, dm, buff buffinfection main, q-->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection severity set to:"/> -->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="infectionSeverity"/> -->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection timer set to:"/> -->
-    <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="$infectionMaxDuration"/> -->
+      <!-- DEBUGGING -->
+      <!-- f1, dm, buff buffinfection main, q-->
+      <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection severity set to:"/> -->
+      <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="infectionSeverity"/> -->
+      <!-- <triggered_effect trigger="onSelfBuffStart" action="LogMessage" message="DOUGHS-BUFF_INFECTION DEBUG: Infection timer set to:"/> -->
+      <!-- <triggered_effect trigger="onSelfBuffStart" action="CVarLogValue" cvar="$infectionMaxDuration"/> -->
 
-    <!-- cleanup, as it seems to be set to the lowest it hit last time and does not reset -->
-    <triggered_effect trigger="onSelfBuffRemove" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800"/>
-  
-  </effect_group>
+      <!-- cleanup, as it seems to be set to the lowest it hit last time and does not reset -->
+      <triggered_effect trigger="onSelfBuffRemove" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800"/>
+
+    </effect_group>
 
   </insertBefore>
 </Doughs>

--- a/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
+++ b/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
@@ -1,6 +1,6 @@
 <Doughs>
   <!--
-  Set to 10800 = 2 hour [real time not game time]
+  Set to 10800 = 3 hour [real time not game time]
   a19 default = 25200 = 7 hours [real time not game time]
 -->
 

--- a/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
+++ b/Doughs-Ailment-InfectionIsRandomAndQuicker/Config/buffs.xml
@@ -1,46 +1,39 @@
 <Doughs>
   <!--
-  Set to 10800 = 3 hour [real time not game time]
-  a19 default = 25200 = 7 hours [real time not game time]
+    Set to 10800 = 3 hour [real time not game time]
+    a19 default = 25200 = 7 hours [real time not game time]
 -->
 
-  <!-- WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
-SEE buffx.xml "RandomRoll" docs for a literal reference to this!
-<triggered_effect trigger="onSelfEnteredGame" action="ModifyCVar" cvar="$doughsGeneticInfectionMarker" operation="set" value="0"/>
-<requirement name="CVarCompare" cvar="$foodAmountAdd" operation="LTE" value="@$doughsGeneticInfectionMarker"/>
-
-# Maybe indulge in this?
-<triggered_effect trigger="onSelfBuffUpdate" action="ModifyCVar" cvar="test2" operation="set" value="randomint(1,10)"/>
-
+  <!--
+    Handle making random of how long it takes to die
+    15% chance of having 3 hours (10800 seconds) [real time]
+    20% chance of having 2 hours (7200 seconds)
+    25% chance of having 1.5 hours (5400 seconds)
+    25% chance of having 1 hour (3600 seconds)
+    10% chance of having 45 minutes (2700 seconds)
+    5% chance of having 30 minutes (1800 seconds)
 -->
 
-  <!-- Set vanilla default buff entry point -->
-  <!-- 
-<set xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set']/@value">10800</set>
+  <!--
+    WIP: If we want to try to punish on dying or something, set a 'genetic marker' counting deaths/infections?
+    SEE buffx.xml "RandomRoll" docs for a literal reference to this!
+    <triggered_effect trigger="onSelfEnteredGame" action="ModifyCVar" cvar="$doughsGeneticInfectionMarker" operation="set" value="0"/>
+    <requirement name="CVarCompare" cvar="$foodAmountAdd" operation="LTE" value="@$doughsGeneticInfectionMarker"/>
+
+    # Maybe indulge in this?
+    <triggered_effect trigger="onSelfBuffUpdate" action="ModifyCVar" cvar="test2" operation="set" value="randomint(1,10)"/>
 -->
 
   <!-- Delete this as were moving it into our own effect group -->
   <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']/requirement"/>
   <remove xpath="/buffs/buff[@name='buffInfectionMain']/effect_group/triggered_effect[@trigger='onSelfBuffStart'][@cvar='$infectionMaxDuration'][@operation='set'][@value='25200']"/>
 
-  <!--
- Handle "making random of how long it takes to die
- 15% chance of having 3 hours (10800 seconds) [real time]
- 20% chance of having 2 hours (7200 seconds)
- 25% chance of having 1.5 hours (5400 seconds)
- 25% chance of having 1 hour (3600 seconds)
- 10% chance of having 45 minutes (2700 seconds)
- 5% chance of having 30 minutes (1800 seconds)
--->
-  <!-- Add randomness to vanilla default buff entry point
-NOTE: randomint rolls 1 time and the result is applied for all
--->
-  <!-- <append xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
-  -->
+  <!-- Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
   <insertBefore xpath="/buffs/buff[@name='buffInfectionMain']/effect_group[not(contains(@name, 'main loop')) and not(contains(@name, 'shut down')) and not(contains(@name, 'display % values')) and not(contains(@name, 'signaling buffs')) and not(contains(@name, 'getting hit makes it worse'))]">
 
-    <effect_group>      <!--Add ours at the beginning to set and calc infectionMaxDuration properly. Must go before all things as this is a major var in calcs -->
+    <effect_group>
 
+      <!-- Add randomness to vanilla default buff entry point (NOTE: randomint rolls 1 time and the result is applied for all) -->
       <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="infectionSeverity" operation="set" value="randomint(0,100)"/>
 
       <triggered_effect trigger="onSelfBuffStart" action="ModifyCVar" cvar="$infectionMaxDuration" operation="set" value="10800">        <!-- 180 minutes -->


### PR DESCRIPTION
I noticed the shorter infections had a higher probability than expected. The problem was that the code could keep rolling into shorter and shorter infections.

Example, 
- at first infection is 10800, so it enters the 7200 block
- lets assume the first roll < 85, so the infection is set to 7200
- because infection is 7200, it enters the 5400 block
- it rolls again, and lets assume the roll is < 65, so the infection is set to 5400
- because infection is 5400, it enters the 3600 block
- it rolls again, lets assume the that roll **_not_** < 40, so it does nothing, staying at 5400
- because of that the remaining blocks have no effect and infection stays at 5400

In this case it should have been 7200, but it kept rolling down to 5400.

This change fixes the problem by rolling once at the beginning and not again.